### PR TITLE
mediarecorder: It's blob.type, not blob.mimeType.

### DIFF
--- a/webapi/mediarecorder/common.js
+++ b/webapi/mediarecorder/common.js
@@ -20,7 +20,7 @@ function updateBlobURLUI(blob) {
 
     var mediaElementType = null;
 
-    if (blob.mimeType.indexOf('audio') !== -1) {
+    if (blob.type.indexOf('audio') !== -1) {
       mediaElementType = 'audio';
     } else {
       mediaElementType = 'video';


### PR DESCRIPTION
The fix unbreaks the test for me in Firefox 30.
